### PR TITLE
Revert "add temp CI job to test syspolicy impact"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,18 +23,3 @@ jobs:
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
     - name: build
       run: nix-build
-  macos_perf_test:
-    runs-on: macos-latest
-    steps:
-    - name: Disable syspolicy assessments
-      run: |
-        spctl --status
-        sudo spctl --master-disable
-    - uses: actions/checkout@v2
-    - uses: cachix/install-nix-action@v8
-    - uses: cachix/cachix-action@v6
-      with:
-        name: purehs
-        signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
-    - name: build
-      run: nix-build


### PR DESCRIPTION
Reverts grumply/pure-platform#26

Thanks for your help testing this out. The results were a bit of a bust with respect to any short-term hope of speeding up macOS builds, but they did help me tease out the fact that the approach I used here doesn't disable the whole assessment--it just appears to keep the assessment's result from being used.

With the approach used here ruled out, the only way I'm aware of to fully disable the assessments and reclaim the associated time requires a GUI to set up.